### PR TITLE
docs: explain the governed AOCI workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ When model context is limited, an AI Agent can read the index first, acquire mos
 
 Names in this document have the following roles: **AOCI** refers to the cognition paradigm and protocol, while **AOCI-CODE** refers to the project and the index itself that embody this method.
 
+## ⚙️ How AOCI works
+
+1. **Establish governed cognition**: The model reads source code and accepted evidence, while AOCI-CODE governs Managed Scope and model-authored cognition for managed objects with the `index` role.
+2. **Deliver cognition before action**: The Agent reads the Rules, live Guide, and current Whole-Index, then checks source and other evidence for the task at hand.
+3. **Maintain cognition after verified change**: Once code and tests are stable, project Rules and the AOCI MCP workflow guide the Agent to update affected Entries and return formal cognition to `aligned`.
 
 ## 🚀 One-step setup
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -34,6 +34,11 @@ AOCI-CODE 源于 AOCI。简单来说，AOCI-CODE 会对源代码、数据库结�
 
 本文中的名称分工如下：**AOCI** 指认知范式和协议，**AOCI-CODE** 指承载该方法的项目与索引本身。
 
+## ⚙️ AOCI 如何工作
+
+1. **建立受治理的认知**：模型读取源代码和已接受的证据；AOCI-CODE 治理 Managed Scope，以及模型为具有 `index` 角色的受管对象创作的认知。
+2. **行动前交付认知**：Agent 读取 Rules、实时 Guide 和当前 Whole-Index，再针对当前任务核对源码与其他证据。
+3. **在变更验证后维护认知**：代码与测试稳定后，项目 Rules 和 AOCI MCP 工作流会引导 Agent 更新受影响的 Entries，并让正式认知回到 `aligned`。
 
 ## 🚀 一键使用
 


### PR DESCRIPTION
## Summary

- add a concise three-stage explanation of how AOCI establishes, delivers, and maintains governed cognition
- keep the English and Chinese additions sentence-for-sentence aligned
- rebuild the PR as a strict additive change on the requested `ca651ec` baseline

## Review feedback addressed

- preserves the unified AOCI logo alt text and the top `[!IMPORTANT]` release-verification banner
- preserves host-config `.gitignore` guidance and Ledger / Verify History write boundaries
- preserves all PostgreSQL, MySQL, and openGauss documentation, including the `verify-full`, TLS 1.2, and loopback-only `sslmode=disable` boundaries
- preserves every byte-pinned public-documentation anchor, including `basic, recommended, or full verification level`
- limits Entries to managed objects with the `index` role and describes maintenance as Rules- and Guide-driven
- avoids the overstated full-restart claim and keeps the executable name as `aoci` (`aoci.exe` on Windows)
- removes the draft Index example instead of duplicating or drifting from the governed tag dictionary
- contains no empty headings

## Diff scope

- `README.md`: 5 insertions, 0 deletions
- `README.zh-CN.md`: 5 insertions, 0 deletions
- no other files changed

## Validation

- `git diff --check ca651ec...HEAD`
- `go test ./internal/safety -run '^TestPublicDocumentationRoutesVolumesAndReleaseVerification$' -count=1`
- `go run ./internal/safetycmd README.md README.zh-CN.md`
- `go test ./textassets -count=1`
- `go test ./internal/dbevidence -count=1`
- `go vet ./...`
- fast-gate dependency check, public-text scan, Linux build, and Windows build
- the three Windows contention-sensitive packages from the aggregate fast run passed isolated serial reruns