### PR TITLE
docs: expand the governed AOCI workflow explanation

### DIFF
--- a/.aoci/baseline.json
+++ b/.aoci/baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "created_at": "2026-08-07T17:44:36Z",
-  "updated_at": "2026-08-15T09:20:06Z",
+  "updated_at": "2026-08-15T09:49:56Z",
   "files": {
     ".gitattributes": {
       "sha256": "21fa16a2122e2b0360b47502c577428b645437e08e9e87ffba661f84853cb476",
@@ -97,14 +97,14 @@
       "normalized_sha256": "9e86829429193738724179195efc9fa40b5c8b69cf865fd31fbc7f7ef4c1dd60"
     },
     "README.md": {
-      "sha256": "ba04191d513ba3a0338c1417feffe495d7844c1d46578325b4a3a752c1430477",
-      "size": 59410,
-      "normalized_sha256": "ba04191d513ba3a0338c1417feffe495d7844c1d46578325b4a3a752c1430477"
+      "sha256": "0519cfb52da39703439d616b0e0bb69f505ac538b9c47b9324c898682672ffe3",
+      "size": 63220,
+      "normalized_sha256": "0519cfb52da39703439d616b0e0bb69f505ac538b9c47b9324c898682672ffe3"
     },
     "README.zh-CN.md": {
-      "sha256": "abcb8fd8a7c303538b2aef5ce94464bfd6ed58c3e6cdf3ef7ef99350a6db6ae1",
-      "size": 51118,
-      "normalized_sha256": "abcb8fd8a7c303538b2aef5ce94464bfd6ed58c3e6cdf3ef7ef99350a6db6ae1"
+      "sha256": "e2f93f007c11daed4a942c77719f6cb869dadec567a2861d35b9571f996ca73c",
+      "size": 54430,
+      "normalized_sha256": "e2f93f007c11daed4a942c77719f6cb869dadec567a2861d35b9571f996ca73c"
     },
     "SECURITY.md": {
       "role": "index",

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ The model authors these semantics from actual source code and evidence. AOCI-COD
 
 ### 🏷️ Reading the starter tag dictionary
 
-The following excerpt is copied verbatim from the current [`en-US` Volume Meta template](textassets/en-US/templates/volume-meta.txt.tmpl). It is a starter dictionary, not a universal vocabulary: each repository's formal Meta remains authoritative. The starter declares no D dictionary; D remains an optional axis and may be used only when the current formal Meta declares it.
+The following excerpt is copied verbatim from the current `en-US` Volume Meta template (`textassets/en-US/templates/volume-meta.txt.tmpl`). It is a starter dictionary, not a universal vocabulary: each repository's formal Meta remains authoritative. The starter declares no D dictionary; D remains an optional axis and may be used only when the current formal Meta declares it.
 
 <details>
 <summary>Show the governed starter dictionary</summary>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Large models handle reasoning, Agents handle planning and execution, and AOCI or
 
 AOCI-CODE originates from AOCI. Put simply, AOCI-CODE distills the information from source code, database structures, and other assets that materially affects how AI understands and modifies a system into a high-information-density, plain-text index combining symbols and semantics.
 
+AOCI-CODE applies this method to projects through the `aoci` CLI and MCP Server.
+
 When model context is limited, an AI Agent can read the index first, acquire most of the project’s key information in one pass, and then enter a specific development task. This reduces repeated searching and code re-learning while improving continuity across tasks and sessions.
 
 - **The index is not a one-time summary**: it evolves with the system and remains in the project over the long term, where it can be diffed, reviewed, versioned, and rolled back with Git.
@@ -36,9 +38,20 @@ Names in this document have the following roles: **AOCI** refers to the cognitio
 
 ## ⚙️ How AOCI works
 
+In the current Volume-first layout, AOCI-CODE organizes the index as governed, plain-text cognition assets stored with the project:
+
+- **Root (`aoci.txt`)**: declares the composition and activation entry point of the current CognitionSet;
+- **Meta (`aoci.meta.txt`)**: stores the tag dictionary, FRAS rules, and model-authoring constraints;
+- **Code (`aoci.code.txt`)**: stores model-authored cognition for code and other repository assets;
+- **Database (`aoci.database.txt`)**: stores optional table-level cognition when Database Cognition is enabled.
+
+Root, Meta, and participating object Volumes together form the current Whole-Index. On top of these assets, the workflow has three stages:
+
 1. **Establish governed cognition**: The model reads source code and accepted evidence, while AOCI-CODE governs Managed Scope and model-authored cognition for managed objects with the `index` role.
 2. **Deliver cognition before action**: The Agent reads the Rules, live Guide, and current Whole-Index, then checks source and other evidence for the task at hand.
 3. **Maintain cognition after verified change**: Once code and tests are stable, project Rules and the AOCI MCP workflow guide the Agent to update affected Entries and return formal cognition to `aligned`.
+
+These plain-text cognition assets are stored with the project and can be versioned with Git. When cognition remains aligned with the current system version, different AI Agents and later sessions can read and reuse the same Whole-Index.
 
 ## 🚀 One-step setup
 
@@ -396,6 +409,33 @@ Compact tags give each object coordinates for architectural layer, functional do
 - the original file must be preserved after a write failure.
 
 The model authors these semantics from actual source code and evidence. AOCI-CODE validates Entry structure, binds the source file, and governs how the Entry enters the formal index.
+
+### 🏷️ Reading the starter tag dictionary
+
+The following excerpt is copied verbatim from the current [`en-US` Volume Meta template](textassets/en-US/templates/volume-meta.txt.tmpl). It is a starter dictionary, not a universal vocabulary: each repository's formal Meta remains authoritative. The starter declares no D dictionary; D remains an optional axis and may be used only when the current formal Meta declares it.
+
+<details>
+<summary>Show the governed starter dictionary</summary>
+
+```text
+#Canonical-Tag-Authoring: compact A+B+C+[D]+E; dotted form is read compatibility only
+#Code canonical identity example: code:path/to/file.go
+#Code Entry example: file.go[EG7T]: F:Runs the example application | R:- | A:- | S:-
+#[Tag dictionary: code]
+#A Layer: C-SharedFoundation E-EntryBoundary A-ApplicationOrchestration D-DomainLogic K-AlgorithmComputation M-Middleware P-Persistence I-IntegrationAdapter R-RuntimeFoundation L-LibrarySDK F-DeclarativeConfiguration O-OperationsDelivery T-TestValidation S-DocumentationSpecification X-DevelopmentTooling Z-Other
+#B Module: G-CrossDomain U-UserInteraction B-CoreBusiness D-DataState I-IdentityAccess N-NetworkProtocol M-MessageEvent S-SecurityPrivacy C-ConfigurationPolicy O-Observability R-ReliabilityRecovery P-PerformanceResource W-WorkflowScheduling A-AnalyticsIntelligence H-HardwareDevice L-Localization V-BuildRelease Q-QualityAssurance E-ExtensionPlugin Z-Other
+#C Importance: 9-highest 8-very-high 7-high 6-above-average 5-medium 4-below-average 3-low 2-very-low 1-lowest
+#E Scale: L-large>400 M-medium200-400 S-small100-200 T-tiny<100
+#[Tag dictionary: database]
+#A Layer: E-EntityMaster T-TransactionFact R-RelationMapping M-DetailDependent C-ReferenceDictionary S-StateStorage H-HistoryVersion L-LogAudit Q-QueueOutbox A-AggregateProjection K-KeyValueConfiguration B-DocumentLargeObject Z-Other
+#B Module: G-CrossDomain B-CoreBusiness I-IdentityAccess T-OrganizationTenant U-UserExperience F-FinanceBilling K-ContentKnowledge C-ConfigurationPolicy W-WorkflowTask M-MessageEvent N-ExternalIntegration S-SecurityPrivacy O-ObservabilityAudit R-ReliabilityRecovery P-PerformanceResource A-AnalyticsIntelligence H-HardwareDevice L-Localization V-BuildRelease Q-QualityTesting E-ExtensionPlugin Z-Other
+#C Importance: 9-highest 8-very-high 7-high 6-above-average 5-medium 4-below-average 3-low 2-very-low 1-lowest
+#E Scale: L-large>400 M-medium200-400 S-small100-200 T-tiny<100
+```
+
+</details>
+
+Under the starter Code dictionary, `[CG9L]` means `C` SharedFoundation, `G` CrossDomain, `9` highest importance, and `L` large scale; no D value is present. This explains how to read the existing Entry, not how the model should assign tags. The model must still choose tags from the current project Meta based on source and accepted evidence.
 
 ## 📚 Cognition Volumes
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -401,7 +401,7 @@ S: F、R、A 之外的重要补充信息
 
 ### 🏷️ 阅读初始标签字典
 
-下面内容从当前 [`zh-CN` Volume Meta 模板](textassets/zh-CN/templates/volume-meta.txt.tmpl)逐字引用。这是一份初始字典，不是所有项目通用的固定词表：每个仓库仍以自身正式 Meta 为准。初始模板没有声明 D 字典；D 仍是可选维度，只有当前正式 Meta 声明后才能使用。
+下面内容从当前 `zh-CN` Volume Meta 模板（`textassets/zh-CN/templates/volume-meta.txt.tmpl`）逐字引用。这是一份初始字典，不是所有项目通用的固定词表：每个仓库仍以自身正式 Meta 为准。初始模板没有声明 D 字典；D 仍是可选维度，只有当前正式 Meta 声明后才能使用。
 
 <details>
 <summary>查看受治理的初始字典</summary>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,6 +24,8 @@
 
 AOCI-CODE 源于 AOCI。简单来说，AOCI-CODE 会对源代码、数据库结构及其他真正影响 AI 理解和修改的关键信息进行压缩，形成符号与语义结合的高信息密度索引，并用纯文本表示。
 
+AOCI-CODE 通过 `aoci` CLI 和 MCP Server 将这套方法落实到项目中。
+
 在模型上下文有限的情况下，AI Agent 可以先读取这套索引，一次性获得项目的大部分关键信息，再进入具体开发任务，从而减少反复搜索和重新理解代码的成本，提高跨任务、跨会话的开发衔接效率。
 
 - **索引不是一次性摘要**：索引会随系统持续演进，长期保存在项目中，可以通过 Git 比较差异、审查、版本化和回滚。
@@ -36,9 +38,20 @@ AOCI-CODE 源于 AOCI。简单来说，AOCI-CODE 会对源代码、数据库结�
 
 ## ⚙️ AOCI 如何工作
 
+在当前 Volume-first 布局中，AOCI-CODE 将索引组织为随项目保存、受治理的纯文本认知资产：
+
+- **Root（`aoci.txt`）**：声明当前 CognitionSet 的组成和激活入口；
+- **Meta（`aoci.meta.txt`）**：保存标签字典、FRAS 规则与模型创作约束；
+- **Code（`aoci.code.txt`）**：保存代码及其他仓库资产的模型创作认知；
+- **Database（`aoci.database.txt`）**：启用 Database Cognition 时保存可选的表级认知。
+
+Root、Meta 与参与其中的对象 Volume 共同组成当前 Whole-Index。在这些资产之上，工作流分为三个阶段：
+
 1. **建立受治理的认知**：模型读取源代码和已接受的证据；AOCI-CODE 治理 Managed Scope，以及模型为具有 `index` 角色的受管对象创作的认知。
 2. **行动前交付认知**：Agent 读取 Rules、实时 Guide 和当前 Whole-Index，再针对当前任务核对源码与其他证据。
 3. **在变更验证后维护认知**：代码与测试稳定后，项目 Rules 和 AOCI MCP 工作流会引导 Agent 更新受影响的 Entries，并让正式认知回到 `aligned`。
+
+这些纯文本认知资产随项目保存并可由 Git 版本化。当认知与当前系统版本保持一致时，不同 AI Agent 和后续会话可以读取并复用同一份 Whole-Index。
 
 ## 🚀 一键使用
 
@@ -385,6 +398,33 @@ S: F、R、A 之外的重要补充信息
 - 写入失败时必须保留原始文件。
 
 模型负责根据真实源码和证据编写这些语义；AOCI-CODE 负责验证条目结构、绑定源文件，并治理它如何进入正式索引。
+
+### 🏷️ 阅读初始标签字典
+
+下面内容从当前 [`zh-CN` Volume Meta 模板](textassets/zh-CN/templates/volume-meta.txt.tmpl)逐字引用。这是一份初始字典，不是所有项目通用的固定词表：每个仓库仍以自身正式 Meta 为准。初始模板没有声明 D 字典；D 仍是可选维度，只有当前正式 Meta 声明后才能使用。
+
+<details>
+<summary>查看受治理的初始字典</summary>
+
+```text
+#Canonical-Tag-Authoring: compact A+B+C+[D]+E; dotted形态仅用于读取兼容
+#Code canonical identity example: code:path/to/file.go
+#Code Entry example: file.go[EG7T]: F:运行示例应用 | R:- | A:- | S:-
+#[Tag dictionary: code]
+#A Layer: C-共享基础 E-入口边界 A-应用编排 D-领域逻辑 K-算法计算 M-中间件 P-持久化 I-集成适配 R-运行基础 L-库与SDK F-声明配置 O-运维交付 T-测试验证 S-文档规范 X-开发工具 Z-其他
+#B Module: G-跨域通用 U-用户交互 B-核心业务 D-数据状态 I-身份权限 N-网络协议 M-消息事件 S-安全隐私 C-配置策略 O-可观测性 R-可靠性恢复 P-性能资源 W-流程调度 A-分析智能 H-硬件设备 L-本地化 V-构建发布 Q-质量保障 E-扩展插件 Z-其他
+#C Importance: 9-最高 8-很高 7-高 6-较高 5-中等 4-较低 3-低 2-很低 1-最低
+#E Scale: L-大>400 M-中200-400 S-小100-200 T-微<100
+#[Tag dictionary: database]
+#A Layer: E-实体主表 T-事务事实 R-关联映射 M-明细从属 C-参考字典 S-状态存储 H-历史版本 L-日志审计 Q-队列发件 A-聚合投影 K-键值配置 B-文档大对象 Z-其他
+#B Module: G-跨域通用 B-核心业务 I-身份权限 T-组织租户 U-用户体验 F-财务计费 K-内容知识 C-配置策略 W-流程任务 M-消息事件 N-外部集成 S-安全隐私 O-可观测审计 R-可靠性恢复 P-性能资源 A-分析智能 H-硬件设备 L-本地化 V-构建发布 Q-质量测试 E-扩展插件 Z-其他
+#C Importance: 9-最高 8-很高 7-高 6-较高 5-中等 4-较低 3-低 2-很低 1-最低
+#E Scale: L-大>400 M-中200-400 S-小100-200 T-微<100
+```
+
+</details>
+
+按照初始 Code 字典，`[CG9L]` 表示 `C` 共享基础、`G` 跨域通用、`9` 最高重要度、`L` 大规模；其中没有 D 值。这段内容只解释如何阅读现有 Entry，不规定模型应该怎样分配标签。模型仍须依据源码和已接受证据，从当前项目 Meta 中选择标签。
 
 ## 📚 Cognition Volumes
 


### PR DESCRIPTION
## Summary

- explain how the current Volume-first layout organizes Root, Meta, Code, and optional Database cognition
- connect Whole-Index creation, delivery, governed maintenance, and cross-Agent/session reuse
- clarify that AOCI-CODE applies the method through the `aoci` CLI and MCP Server
- add a collapsible starter tag dictionary copied verbatim from the governed bilingual Volume Meta templates

## Scope and governance

- README changes remain strictly additive: `README.md` +40/-0 and `README.zh-CN.md` +40/-0
- `.aoci/baseline.json` advances only the two README records and was generated through the repository's Rules → Guide → Maintain/update-entry → Verify/Check/Guide workflow, not edited by hand
- preserves the previously approved three-stage workflow text
- keeps English and Chinese additions sentence-for-sentence aligned
- does not restore the obsolete three-file model, automatic MCP alignment, blanket restart, one-file-one-Entry, or incorrect executable-name claims
- leaves each repository's formal Meta authoritative; optional D tags are valid only when the formal Meta declares them
- renders the governed template locations as inline code so README references remain valid inside release archives

## Validation

- `git diff --check`
- `go test ./scripts/release/archive-smoke -run '^TestArchiveREADMERelativeLinksResolveInsideArchive$' -count=1`
- `go test ./internal/safety -run '^TestPublicDocumentationRoutesVolumesAndReleaseVerification$' -count=1`
- `go run ./internal/safetycmd README.md README.zh-CN.md`
- `go test ./textassets -count=1`
- `go test ./internal/dbevidence -count=1`
- `go test ./internal/cli -run '^TestReadObservationContractIsSharedByHelpAndDocs$' -count=1`
- full MCP blackbox conformance: 58 passed, 0 failed
- AOCI Verify and Check passed; final Guide reports `complete`, `aligned`, and no missing, stale, orphaned, or unbaselined objects
- `go vet ./...` and Linux/Windows fast builds passed in a clean LF worktree
- all 667 governed Go files passed batched `gofmt -l`; three unrelated Windows-local parallel lock/performance tests passed when rerun serially
- verified both embedded dictionary blocks match their governed templates byte-for-byte
