### PR TITLE
docs: split the setup instruction into the two turns it always was

### DIFF
--- a/.aoci/baseline.json
+++ b/.aoci/baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "created_at": "2026-08-07T17:44:36Z",
-  "updated_at": "2026-08-15T19:05:42Z",
+  "updated_at": "2026-08-15T20:09:17Z",
   "files": {
     ".gitattributes": {
       "sha256": "21fa16a2122e2b0360b47502c577428b645437e08e9e87ffba661f84853cb476",
@@ -55,9 +55,9 @@
       "normalized_sha256": "ba845b2baf97528f2278b600959f37c8243fec0c5643b2b56919b27272e91923"
     },
     "CHANGELOG.md": {
-      "sha256": "ed89a9de88e6148e3a0d92faf5664fbabee9f7524f403474bb36300436253cac",
-      "size": 23931,
-      "normalized_sha256": "ed89a9de88e6148e3a0d92faf5664fbabee9f7524f403474bb36300436253cac"
+      "sha256": "3ddc4f5ec23fff82f6875b80ec89c9a164c549eb89f391f1bb16a90d5a2253de",
+      "size": 24945,
+      "normalized_sha256": "3ddc4f5ec23fff82f6875b80ec89c9a164c549eb89f391f1bb16a90d5a2253de"
     },
     "CODE_OF_CONDUCT.md": {
       "role": "index",
@@ -94,14 +94,14 @@
       "normalized_sha256": "9e86829429193738724179195efc9fa40b5c8b69cf865fd31fbc7f7ef4c1dd60"
     },
     "README.md": {
-      "sha256": "dc3e63083ea4bc2a889130acfb947d2b07d220e463aa9457e26a2b75b9790477",
-      "size": 65539,
-      "normalized_sha256": "dc3e63083ea4bc2a889130acfb947d2b07d220e463aa9457e26a2b75b9790477"
+      "sha256": "127cf57515a1db6357b44ee28eeba80ba49e4b51878fba815ec1f709a641c2c0",
+      "size": 67307,
+      "normalized_sha256": "127cf57515a1db6357b44ee28eeba80ba49e4b51878fba815ec1f709a641c2c0"
     },
     "README.zh-CN.md": {
-      "sha256": "46083fcfa54d96dbd072aca93988a73871ea712495a306baa6a2b34424ca6986",
-      "size": 56733,
-      "normalized_sha256": "46083fcfa54d96dbd072aca93988a73871ea712495a306baa6a2b34424ca6986"
+      "sha256": "5c9857c6113c7dcb119f83669bea2ca4c009fe6ae7b9c0ec156e1d26008383cb",
+      "size": 58295,
+      "normalized_sha256": "5c9857c6113c7dcb119f83669bea2ca4c009fe6ae7b9c0ec156e1d26008383cb"
     },
     "SECURITY.md": {
       "role": "index",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable public changes to AOCI-CODE will be documented in this file.
 
 ## Unreleased
 
+- Split the one-step setup instruction in both public READMEs into the two turns
+  it always was. The index is authored through AOCI's MCP tools, and the server
+  `init` writes is not loaded in the session that wrote it, so the old single
+  prompt asked the Agent to finish work it could not reach. The first
+  instruction now runs `init` and `scan`, asks for any configuration a host does
+  not write itself, and stops with an explicit restart hand-off; the second
+  confirms the MCP server and builds the index. `scan`, which establishes the
+  Baseline every later step needs, was missing from the one-step path entirely.
+- Say in both READMEs how to tell which AOCI a host is actually connected to:
+  `cognition_receipt.mcp_service_version` and `runtime_repository_root` from any
+  Overview `check_only` response or any Maintain response, and the `command` in
+  the project's `.mcp.json` or the equivalent host configuration for the binary
+  path. Replacing bytes on disk does not change a running MCP process.
 - Carry the `aoci scope acknowledge` remediation in a blocked Volumes Guide whose
   Observe evidence is pending review. `observe_change_policy` defaults to
   `review_required`, so an ordinary edit to any Observe-role file blocks

--- a/README.md
+++ b/README.md
@@ -55,21 +55,37 @@ These plain-text cognition assets are stored with the project and can be version
 
 ## 🚀 One-step setup
 
-Give the following instruction to your AI Agent to download AOCI-CODE, integrate it, and build an index for the current project:
+Give the following instruction to your AI Agent to download AOCI-CODE and integrate it; after restarting the Agent, send the second instruction to build the index:
 
 ```text
 AOCI-CODE project: https://github.com/aoci-spec/aoci-code
 
 Download the latest release package for this operating system and CPU architecture from
 https://github.com/aoci-spec/aoci-code/releases, and follow the installation instructions
-on the Release page to verify it.
+on the Release page to verify it. If no compatible release package exists, or if I
+explicitly request the latest source, build it from the official repository.
 
 After extracting the package, place aoci (aoci.exe on Windows) at a stable absolute path.
-Then initialize AOCI for my project, integrate MCP, and build the project index.
+Then use that absolute path to do the following for my project:
 
-If no compatible release package exists, or if I explicitly request the latest source,
-build it from the official repository.
+1. Run init to initialize AOCI and integrate MCP for the current host; if this host does
+   not write project configuration (Cursor, for example), give me the configuration I
+   need to paste myself
+2. Run scan
+3. Tell me to restart the Agent so the newly written MCP server takes effect
+
+Stop after those three steps and do not build the index yet — I will tell you to continue
+after the restart.
 ```
+
+After restarting the Agent, send this one:
+
+```text
+First confirm the AOCI MCP server is connected, then build the AOCI index for this project.
+```
+
+The index is authored through AOCI's MCP tools, and the MCP server that `init` has just written was not loaded in the session that wrote it, so index building has to follow the restart. A host that loads MCP servers dynamically may not need one; “Host integration” explains how to tell.
+
 ## 🔌 Manual integration
 
 Obtain AOCI-CODE from canonical source or use a signed package from GitHub Releases. Before using a prebuilt binary, follow the basic, recommended, or full verification level in the [installation guide](https://github.com/aoci-spec/aoci-code/blob/v0.1.0-rc4/docs/install.md#signed-github-release-packages), and report which level completed. Give this README and the verified binary's stable absolute path to a trusted AI Agent such as Codex, Claude Code, Cursor, or OpenCode. The AI Agent can follow the in-project instructions to initialize AOCI, integrate MCP, and build the first index.
@@ -130,7 +146,8 @@ Then provide this README to an AI Agent that you already trust for the project a
 
 ```text
 Read this AOCI-CODE README and use the built aoci binary at its stable absolute path
-to initialize AOCI for the current project, integrate MCP, and then build the index.
+to initialize AOCI for the current project, integrate MCP, and run scan. Stop there and
+tell me to restart the Agent; I will ask you to build the index afterwards.
 ```
 
 The AI Agent should identify the current project root, use a stable absolute path to the built binary, perform the initialization appropriate for the current host, and clearly tell the user when a host restart or genuine human approval is required. The build output may remain in the AOCI-CODE source checkout or be placed in a shared stable tools directory, provided that the MCP configuration references the correct absolute path.
@@ -164,10 +181,10 @@ Confirm that `$Aoci` points to a stable absolute path.
 
 ### 3. 🤖 Have the AI Agent establish cognition for the first time (important)
 
-Enter the following in the AI Agent for the target project:
+Once initialization and `scan` are done, check whether the Agent session already exposes the AOCI tools; refresh or restart it if not. Then enter the following in the AI Agent for the target project:
 
 ```text
-Build an index for this project.
+First confirm the AOCI MCP server is connected, then build the AOCI index for this project.
 ```
 
 The host should read the project’s AOCI Rules and live Guide, inspect source code, tests, configuration, and relevant evidence, and then author FRAS candidates for managed objects whose role is `index`. Regular users do not need to orchestrate Plan, Stage, Check, Diff, CAS, or Apply manually.
@@ -201,6 +218,8 @@ The expected result is for formal cognition and the current managed source code 
 "$AOCI" --repo . capabilities
 "$AOCI" --repo . doctor
 ```
+
+To confirm which AOCI the host is actually connected to, read what the server reports about itself rather than what is on disk: in any `aoci_overview` `check_only` response or any `aoci_maintain` response, `cognition_receipt.mcp_service_version` is the running version and `runtime_repository_root` is the repository it governs. The matching binary path is the `command` in the project's `.mcp.json` or the equivalent host configuration — `.codex/config.toml`, `opencode.json`, or `.cursor/mcp.json`. Replacing bytes on disk does not change a running MCP process, so recheck against those facts after an upgrade or a rollback.
 
 For a one-off walkthrough, use `examples/minimal-repository` in the repository.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,17 +55,30 @@ Root、Meta 与参与其中的对象 Volume 共同组成当前 Whole-Index。在
 
 ## 🚀 一键使用
 
-把下面这段话发给你的 AI Agent，它会下载 AOCI-CODE、完成接入并为当前项目建立索引：
+把下面这段话发给你的 AI Agent，它会下载 AOCI-CODE 并完成接入；重启 Agent 后，再发第二段让它建立索引：
 
 ```text
 AOCI-CODE 项目地址：https://github.com/aoci-spec/aoci-code
 
-请从 https://github.com/aoci-spec/aoci-code/releases 下载适合当前操作系统和 CPU 架构的最新发布包，并按照发布页的安装说明完成校验。
+请从 https://github.com/aoci-spec/aoci-code/releases 下载适合当前操作系统和 CPU 架构的最新发布包，并按照发布页的安装说明完成校验。如果没有适合当前系统的发布包，或者我明确要求使用最新源码，请从官方仓库构建。
 
-解压后，请把 aoci（Windows 为 aoci.exe）放在稳定的绝对路径中，然后为我的项目完成初始化、MCP 接入和索引建立。
+解压后，请把 aoci（Windows 为 aoci.exe）放在稳定的绝对路径中，然后用这个绝对路径为我的项目完成以下任务：
 
-如果没有适合当前系统的发布包，或者我明确要求使用最新源码，请从官方仓库构建。
+1. 运行 init，完成初始化并接入当前宿主的 MCP；如果这个宿主不写入项目配置（例如 Cursor），请把需要我手工粘贴的配置给我
+2. 运行 scan
+3. 提示我重启 Agent，让新写入的 MCP server 生效
+
+这三步做完就停下，先不要建立索引 —— 重启后我会让你继续。
 ```
+
+重启 Agent 之后，再发这一段：
+
+```text
+先确认 AOCI MCP 已接入，然后请为这个项目建立 AOCI 索引。
+```
+
+索引由 AOCI 的 MCP 工具创作，而 `init` 刚写入的 MCP server 在当时那个会话里还没有加载，所以建立索引必须放在重启之后。支持动态加载 MCP 的宿主可能不必重启；判断方法见“宿主集成”。
+
 ## 🔌 手动接入
 
 请从 canonical source 获取 AOCI-CODE，或使用 GitHub Releases 提供的签名包。使用预构建二进制前，请按[安装指南](https://github.com/aoci-spec/aoci-code/blob/v0.1.0-rc4/docs/install.md#signed-github-release-packages)选择基础、推荐或完整校验层级，并准确说明已完成的层级。请把本 README 和已验证二进制的稳定绝对路径交给 Codex、Claude Code、Cursor、OpenCode 等受信任 AI Agent。AI Agent 可以按照项目内的说明运行初始化、完成 MCP 接入并建立第一份索引。
@@ -124,7 +137,8 @@ Copy-Item .\build\aoci .\build\aoci.exe -Force
 
 ```text
 请阅读这份 AOCI-CODE README，使用已构建 aoci 二进制的稳定绝对路径，
-为当前项目完成 AOCI 初始化和 MCP 接入，然后建立索引。
+为当前项目完成 AOCI 初始化和 MCP 接入，并运行 scan。做完就停下并提示我重启
+Agent，重启后我会让你建立索引。
 ```
 
 AI Agent 应识别当前项目根目录、使用已构建二进制的稳定绝对路径、执行适合当前宿主的初始化，并在需要宿主重启或真实人工批准时明确提示用户。构建结果可以保留在 AOCI-CODE 源码工作区，也可以放到统一的稳定工具目录，只要 MCP 配置引用正确的绝对路径。
@@ -158,10 +172,10 @@ $Aoci = (Resolve-Path "C:\path\to\aoci-code\build\aoci.exe").Path
 
 ### 3. 🤖 让 AI Agent 建立第一次认知（重要）
 
-在目标项目的 AI Agent 中输入：
+初始化和 `scan` 完成后，先看当前 Agent 会话里有没有出现 AOCI 工具；没有就刷新或重启它。然后在目标项目的 AI Agent 中输入：
 
 ```text
-请为这个项目建立索引。
+先确认 AOCI MCP 已接入，然后请为这个项目建立 AOCI 索引。
 ```
 
 宿主应读取项目内的 AOCI Rules 和实时 Guide，调查源码、测试、配置及相关证据，然后为 `index` 角色的受管对象创作 FRAS 候选。普通用户无需手工编排 Plan、Stage、Check、Diff、CAS 或 Apply。
@@ -195,6 +209,8 @@ $Aoci = (Resolve-Path "C:\path\to\aoci-code\build\aoci.exe").Path
 "$AOCI" --repo . capabilities
 "$AOCI" --repo . doctor
 ```
+
+要确认宿主此刻真正连着哪一个 AOCI，看服务端自报的身份，而不是磁盘上的文件：任何 `aoci_overview` 的 `check_only` 响应、或任何 `aoci_maintain` 响应里，`cognition_receipt.mcp_service_version` 是正在运行的版本，`runtime_repository_root` 是它治理的仓库。对应的二进制路径是项目 `.mcp.json` 或等价宿主配置（`.codex/config.toml`、`opencode.json`、`.cursor/mcp.json`）里的 `command`。替换磁盘上的字节不会改变已在运行的 MCP 进程，因此升级或回滚后要按这些事实复核。
 
 如需一次性演练，可使用仓库中的 `examples/minimal-repository`。
 


### PR DESCRIPTION
## What changes and why

The index is authored through AOCI's MCP tools. `aoci init` writes the host MCP configuration — but **the session that ran init has not loaded that server**. The one-step prompt nevertheless asked the Agent to initialize, integrate MCP, *and* build the index in one turn: work it could not reach.

It also never ran `scan`. Verified: after `init --agent claude` without scan, `index agent guide --json` returns `stage: "blocked"`, `findings: [baseline_missing, ...]` — the dead end [#8](https://github.com/aoci-spec/aoci-code/issues/8) documented.

**Now:**

| Turn | Instruction |
| --- | --- |
| 1 | download + verify → `init` (+ hand back config for hosts that don't write it, e.g. Cursor) → `scan` → **stop**, tell me to restart |
| 2 | confirm the MCP server → build the index |

Section 1's prompt carried the same single-session shape and is split the same way. Section 3 now reuses turn 2 **verbatim** (md5-checked identical per locale) so the two copies cannot drift.

Both locales keep the **conditional** reload rule — `docs/agent-integrations.md` is the authority and a dynamic-reload host may need nothing — rather than demanding a blanket restart.

## Also: how to tell which AOCI is actually running

The READMEs never explained this. Section 5 now does: `cognition_receipt.mcp_service_version` and `runtime_repository_root`, plus the `command` in the host config.

Two corrections an adversarial pass caught in my own first draft of that paragraph, both verified against the running server:

- **`aoci_maintain` takes no `check_only`.** Its schema is `{scope, intent, object_refs}` with `additionalProperties: false`; calling it with `check_only` returns `isError: true — unexpected additional properties ["check_only"]`. The draft had fronted the qualifier so it distributed over both tools. Now it binds to Overview alone, matching `textassets/*/contracts/runtime-rules.txt:53`.
- **Only Claude Code writes `.mcp.json`.** Codex → `.codex/config.toml`, OpenCode → `opencode.json` (where `command` is an *array*), Cursor → nothing at all. The draft had dropped the Rules' `(or the equivalent Host configuration)` hedge — while the walkthrough directly above inits with `--agent codex`.

## Affected public contracts

- [x] 无公开合同变化 — documentation only.

兼容性影响：无。

## Verification

- [x] `make fast` · `go vet ./...` · `make staticcheck` (pinned v0.7.0)
- [x] `bash scripts/check-public-text.sh` — 全部干净（413 个文件）
- [x] `python3 scripts/blackbox/mcp_conformance.py` — 46 passed, 0 failed
- [x] `python3 scripts/blackbox/mcp_scenarios.py` — 30 PASS, 0 CHARACTERIZED, 0 FAIL
- [x] Ordering claims proven empirically, not asserted: `init --agent` run in four scratch repos to confirm which file each host gets; `index agent plan` confirmed closed for Volumes v1 (`This command or compatibility write path cannot modify Volumes v1 formal cognition`), so MCP really is the authoring route; `scan` without `init` fails, so the step order is load-bearing
- [x] Locale parity: 88 headings, identical level sequence; turn-2 prompt byte-identical between the setup section and section 3 in each locale; no heading left without a preceding blank line

## Operating system impact

None.

## Migration and recovery

None.

## Cognition

- [x] 受管对象有变化，已完成 AOCI 治理循环（maintain → update_entry → verify/check/guide），且索引与代码在同一提交内

The three Entries' F/R/A/S were already accurate, so `update_entry` applied 3 candidates with **zero formal writes** (`duplicate_applies: 1`) and only the Baseline binding advanced. Guide terminal state: `stage=aligned, complete=true, next_action=none`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)