### PR TITLE
fix(scope): route P0/P1 and coverage-reduction plans in auto mode to independent review

### DIFF
--- a/internal/scopechange/coverage_reduction_approval_test.go
+++ b/internal/scopechange/coverage_reduction_approval_test.go
@@ -1,0 +1,95 @@
+package scopechange
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aoci-spec/aoci-code/internal/baseline"
+	"github.com/aoci-spec/aoci-code/internal/config"
+	"github.com/aoci-spec/aoci-code/internal/machinecontract"
+	"github.com/aoci-spec/aoci-code/internal/managedscope"
+)
+
+// A cognition coverage reduction (index -> observe) planned under inherit/auto
+// must still have a reviewer. Before the fix, InteractionRequired was derived
+// from the weaker desired mode, so an effective-auto plan reported
+// interaction_required=false: `scope approve` answered
+// managed_scope_approval_not_required while `scope apply`/`scope authorize`
+// were blocked by managed_scope_auto_authorization_blocked
+// (p0_or_p1,cognition_coverage_reduction_requires_independent_review). The
+// blocked change had no approver and the repository was stuck. The block is a
+// fact handed to independent review, not a dead end, so the plan must carry
+// interaction_required and the interactive approval must be able to land it.
+func TestCoverageReductionDemandsAHumanReviewer(t *testing.T) {
+	root, candidates := buildChangeFixture(t)
+	setFixtureAuthorization(t, root, config.AutomationModeAuto, machinecontract.ScopeApprovalModeAuto)
+
+	// Retire the entry and move main_test.go index -> observe through an
+	// ordinary (non-transport) user rule: a real cognition coverage reduction.
+	indexPath := filepath.Join(root, "aoci.txt")
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = []byte(strings.ReplaceAll(string(data), "main_test.go[T.RT.5.T]: F:test | R:main.go | A:- | S:-\n", ""))
+	if err := os.WriteFile(indexPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	state, exists, err := baseline.Load(root)
+	if err != nil || !exists {
+		t.Fatal(err)
+	}
+	fingerprint, err := baseline.HashFile(indexPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fingerprint.Role = machinecontract.ScopeRoleIndex
+	state.Files["aoci.txt"] = fingerprint
+	if err := baseline.Save(root, state); err != nil {
+		t.Fatal(err)
+	}
+	candidates.Dispositions = nil
+	if err := config.MutateManagedScope(root, func(policy *managedscope.Policy) error {
+		policy.Rules = append(policy.Rules, managedscope.Rule{RuleID: "coverage-test-observe", Action: machinecontract.ScopeRoleObserve,
+			Pattern: "main_test.go", PatternKind: machinecontract.ScopePatternFile, Reason: "test-only fixture",
+			DecisionBasis: machinecontract.ScopeDecisionUnspecified, Source: machinecontract.ScopeRuleUser,
+			CreatedBy: "coverage-test", Order: 0, Enabled: true})
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	preview, err := Build(root, authorizationTestTime, candidates)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !preview.Plan.Risk.CognitionCoverageReduction || preview.Plan.Risk.P1 == 0 {
+		t.Fatalf("fixture did not produce a coverage reduction: %+v", preview.Plan.Risk)
+	}
+	if preview.Plan.Risk.TransportConstraintNotAllowed {
+		t.Fatalf("fixture unexpectedly transport-constrained: %+v", preview.Plan.Risk)
+	}
+	if !preview.Plan.InteractionRequired {
+		t.Fatal("a coverage reduction planned under auto still needs a reviewer; " +
+			"without this the auto blocker has no approver and the repository is stuck")
+	}
+	if preview.Plan.ConfirmationPhrase == "" {
+		t.Fatal("an interactive plan must carry the phrase that binds the approval to it")
+	}
+
+	// Policy-bound auto authorization must still refuse a coverage reduction.
+	if _, err := NewPolicyBoundApproval(root, preview, authorizationTestTime); err == nil ||
+		!strings.Contains(err.Error(), "coverage_reduction") {
+		t.Fatalf("policy-bound auto must still refuse a coverage reduction, got %v", err)
+	}
+
+	// A real human approval now lands through the interactive branch.
+	approval, err := NewApproval(preview, "fixture-actor", authorizationTestTime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ApplyAuthorized(root, preview, approval, nil); err != nil {
+		t.Fatalf("an interactively approved coverage reduction must apply: %v", err)
+	}
+}

--- a/internal/scopechange/plan.go
+++ b/internal/scopechange/plan.go
@@ -410,7 +410,22 @@ func Build(repositoryRoot, preparedAt string, candidates CandidateSet) (*Preview
 		// independent review, not to a dead end. Without this the weaker desired
 		// mode would also decide that no reviewer is needed, so the block would
 		// have no approver and auto would become unreachable once left.
-		plan.InteractionRequired = plan.Risk.ApprovalPolicyRelaxation
+		//
+		// The same applies to every other fact autoAuthorizationBlockers refuses
+		// for a reason independent review can ratify: P0/P1 findings and cognition
+		// coverage reductions (e.g. an index->observe role change). If only the
+		// approval-policy relaxation is routed to review, a repository in inherit
+		// (effective auto) mode with a pending coverage reduction gets
+		// interaction_required=false, so `scope approve` answers
+		// managed_scope_approval_not_required while `scope apply`/`authorize` are
+		// blocked by managed_scope_auto_authorization_blocked
+		// (p0_or_p1,cognition_coverage_reduction_requires_independent_review):
+		// the blocked change has no approver and the repository is stuck.
+		plan.InteractionRequired = plan.Risk.ApprovalPolicyRelaxation ||
+			plan.Risk.BudgetRelaxation ||
+			plan.Risk.HighRiskOptIn ||
+			plan.Risk.P0 != 0 || plan.Risk.P1 != 0 ||
+			plan.Risk.CognitionCoverageReduction
 	case machinecontract.ApplyAuthorizationOff:
 		plan.InteractionRequired = false
 	default:


### PR DESCRIPTION
## 问题

在 `approval_mode=inherit`（生效为 auto）的仓库里，任何带有 **认知覆盖缩减**（例如 index → observe 的角色变更）的 Managed Scope 计划都会把仓库卡死：

```
$ aoci scope apply --preview-file preview.json
Error: Managed Scope failed: managed_scope_auto_authorization_blocked: cognition_coverage_reduction_requires_independent_review,p0_or_p1

$ aoci scope authorize --preview-file preview.json
Error: Managed Scope failed: managed_scope_auto_authorization_blocked: cognition_coverage_reduction_requires_independent_review,p0_or_p1

$ aoci scope approve --preview-file preview.json --actor <human> --out-file approval.json
Error: Managed Scope failed: managed_scope_approval_not_required
```

即：自动授权正确地拒绝了这个计划（P0/P1 + 覆盖缩减需要独立评审），但计划没有把 `interaction_required` 置位，`scope approve` 认为“不需要审批”，于是这个被阻断的变更**没有任何审批人**，仓库无法通过官方命令前移（`scan --force` 在 Volumes v1 下也被拒）。

## 根因

`internal/scopechange/plan.go` 中，auto 模式下 `InteractionRequired` 只由 `ApprovalPolicyRelaxation` 推导：

```go
case machinecontract.ApplyAuthorizationAuto:
    plan.InteractionRequired = plan.Risk.ApprovalPolicyRelaxation
```

而 `autoAuthorizationBlockers` 会因 `p0_or_p1` / `cognition_coverage_reduction_requires_independent_review` / `budget_policy_relaxation` / `high_risk_content_inclusion` 拒绝自动授权。这些“被阻断的事实”按设计应转交独立评审（`applyAuthorizationBranch` 已具备把 auto+interaction 计划路由到 review 分支的机制），但 `InteractionRequired` 没有覆盖它们，导致 `scope approve` 无物可批。

## 修复

auto 模式下，凡是 `autoAuthorizationBlockers` 因“可由独立评审批准”的原因而阻断的计划，都把 `InteractionRequired` 置为 true：

```go
plan.InteractionRequired = plan.Risk.ApprovalPolicyRelaxation ||
    plan.Risk.BudgetRelaxation ||
    plan.Risk.HighRiskOptIn ||
    plan.Risk.P0 != 0 || plan.Risk.P1 != 0 ||
    plan.Risk.CognitionCoverageReduction
```

- `scope approve` 现在可以生成审批物；
- `scope apply --approval-file` 通过既有的 `applyAuthorizationBranch` 走交互式评审分支落地；
- `scope authorize`（policy-bound auto）仍按原样拒绝这些计划，不改变“不能自我批准”的安全语义；
- 普通 auto 计划仍完全自动、且继续拒收人工审批。

## 测试

新增 `TestCoverageReductionDemandsAHumanReviewer`（`internal/scopechange/coverage_reduction_approval_test.go`），钉死语义：
1. 计划必须报告 `interaction_required=true` 并携带确认短语；
2. policy-bound auto 仍拒绝覆盖缩减；
3. 真人审批（`NewApproval` + `ApplyAuthorized`）可以落地。

`go test ./internal/scopechange/ ./internal/cli/` 全绿。

## 复现环境备注

测试 fixture 在 macOS 上会因 `/var -> /private/var` 符号链接触发 `safe_inventory_git_boundary_mismatch`（与本次修改无关的既有环境问题），需将 `TMPDIR` 指向非符号链接目录后再跑测试。

## 相关观察（未在本次改动范围）

在排查中另发现两个可能值得跟进的点：
1. **正式卷漂移无恢复路径**：Volumes v1 仓库若 `aoci.code.txt` 被直接修改而未同步 baseline，`scope plan/status` 报 `managed_scope_formal_volume_baseline_drift`，而 `scan --force` 在 Volumes v1 下被拒，官方命令没有恢复出口（只能手工改 baseline.json）。
2. **`index score`/`index inventory` 在 Volumes v1 下拒绝**：这两个被文档描述为只读观测的命令在 Volumes v1 布局下经 `loadIndexForCLI` 直接报 “cannot modify Volumes v1 formal cognition”。
